### PR TITLE
Added a workaround for kernels < 4.10 to solve an error caused by a m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ From the command line, enter `cd <path_to_local_repo>` so that you can enter com
 Enter `git add --all` at the command line to add the files or changes to the repository
 Enter `git commit -m '<commit_message>'` at the command line to commit new files/changes to the local repository. For the <commit_message> , you can enter anything that describes the changes you are committing.
 Enter `git push`  at the command line to copy your files from your local repository to remote.
+
+## Overlayfs-tools Compilation Problems
+If you're having problems compiling overlayfs-tools due to a kernel and stdlib header mismatch see here:
+https://github.com/systemd/systemd/commit/75720bff62a84896e9a0654afc7cf9408cf89a38

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+# set -ex
+
 systemctl -q is-active log2zram  && { echo "ERROR: log2zram service is still running. Please run \"sudo service log2zram stop\" to stop it and uninstall"; exit 1; }
 [ "$(id -u)" -eq 0 ] || { echo "You need to be ROOT (sudo can be used)"; exit 1; }
 [ -d /usr/local/bin/log2zram ] && { echo "Log2Zram is already installed, uninstall first"; exit 1; }
 
-apt-get install libattr1-dev
-git clone https://github.com/kmxz/overlayfs-tools
+# save time (if we can) on slow machines/storage loading and parsing apt package lists
+( dpkg -l | grep -q "libattr1-dev" ) || \
+	apt-get install libattr1-dev -y
+[ -d overlayfs-tools ] || \
+	git clone https://github.com/kmxz/overlayfs-tools
 cd overlayfs-tools
 make
 cd ..
@@ -21,7 +26,4 @@ mkdir -p /usr/local/lib/log2zram/
 install -m 755 overlayfs-tools/overlay /usr/local/lib/log2zram/overlay
 mkdir -p /usr/local/share/log2zram/log
 systemctl enable log2zram
-
-
-
 

--- a/log2zram
+++ b/log2zram
@@ -7,6 +7,8 @@ ZRAM_LOG=/var/log
 ZSHARE=/usr/local/share/log2zram
 ZLOG=${ZSHARE}/log/log2zram.log
 
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+# set -x
 
 createZramLogDrive () {
 	# Check Zram Class created
@@ -28,24 +30,26 @@ mergeOverlay () {
 	./overlay merge -l "${HDD_LOG}" -u "${ZDIR}/zram${DEV_NUM}/upper" >>${ZLOG} 2>&1 || return 1
 	sh -x *.sh  >>${ZLOG} 2>&1 || return 1
 	rm -v *.sh  >>${ZLOG} 2>&1 || return 1
-	
 }
 
 case "$1" in
 	start)
+		set -e
 		echo "log2zram start $(date +%Y-%m-%d-%H:%M:%S)" >>${ZLOG}
-		invoke-rc.d rsyslog stop >>${ZLOG} 2>&1 || exit 1
-		mkdir -p $HDD_LOG  >>${ZLOG} 2>&1 || exit 1
-		mount --verbose --bind $ZRAM_LOG/ $HDD_LOG/ >>${ZLOG} 2>&1 || exit 1
-		mount --verbose --make-private $HDD_LOG/ >>${ZLOG} 2>&1 || exit 1
-		createZramLogDrive >>${ZLOG} 2>&1 || exit 1
-		mkdir -vp ${ZDIR}/zram${DEV_NUM} >>${ZLOG} 2>&1 || exit 1
-		mount --verbose --types ext4 $MNT_OPTS /dev/zram${DEV_NUM} ${ZDIR}/zram${DEV_NUM}/ >>${ZLOG} 2>&1 || exit 1
-		mkdir -vp ${ZDIR}/zram${DEV_NUM}/upper ${ZDIR}/zram${DEV_NUM}/workdir ${ZRAM_LOG} >>${ZLOG} 2>&1 || exit 1
-		mount --verbose --types overlay -o redirect_dir=off,lowerdir=${HDD_LOG},upperdir=${ZDIR}/zram${DEV_NUM}/upper,workdir=${ZDIR}/zram${DEV_NUM}/workdir overlay${DEV_NUM} ${ZRAM_LOG} >>${ZLOG} 2>&1 || exit 1
+		invoke-rc.d rsyslog stop >>${ZLOG} 2>&1
+		mkdir -p $HDD_LOG  >>${ZLOG} 2>&1
+		mount --verbose --bind $ZRAM_LOG/ $HDD_LOG/ >>${ZLOG} 2>&1
+		mount --verbose --make-private $HDD_LOG/ >>${ZLOG} 2>&1
+		createZramLogDrive >>${ZLOG} 2>&1
+		mkdir -vp ${ZDIR}/zram${DEV_NUM} >>${ZLOG} 2>&1
+		mount --verbose --types ext4 $MNT_OPTS /dev/zram${DEV_NUM} ${ZDIR}/zram${DEV_NUM}/ >>${ZLOG} 2>&1
+		mkdir -vp ${ZDIR}/zram${DEV_NUM}/upper ${ZDIR}/zram${DEV_NUM}/workdir ${ZRAM_LOG} >>${ZLOG} 2>&1
+		[ $(version `uname -r`) -le $(version "4.10") ] || IV_X_OPTS="redirect_dir=off,"
+		mount --verbose --types overlay -o ${IV_X_OPTS}lowerdir=${HDD_LOG},upperdir=${ZDIR}/zram${DEV_NUM}/upper,workdir=${ZDIR}/zram${DEV_NUM}/workdir overlay${DEV_NUM} ${ZRAM_LOG} >>${ZLOG} 2>&1
 		echo "/zram${DEV_NUM}" > ${ZSHARE}/zram-device-list
-		invoke-rc.d rsyslog restart >>${ZLOG} 2>&1 || exit 1
-		journalctl --flush >>${ZLOG} 2>&1 || exit 1
+		invoke-rc.d rsyslog restart >>${ZLOG} 2>&1
+		journalctl --flush >>${ZLOG} 2>&1
+		exit 0
 		;;
 
 	stop)
@@ -59,14 +63,14 @@ case "$1" in
 		else
 		sleep .1
 			invoke-rc.d rsyslog stop  >>${ZLOG} 2>&1
-			umount --verbose -l ${ZRAM_LOG}/ >>${ZLOG} 2>&1 
+			umount --verbose -l ${ZRAM_LOG}/ >>${ZLOG} 2>&1
 		fi
 		mergeOverlay >>${ZLOG} 2>&1
 		if umount --verbose ${ZDIR}${ZRAM_DEV}/ >>${ZLOG} 2>&1
 		then
 			echo "umount ${ZDIR}${ZRAM_DEV}/" >>${ZLOG}
 		else
-			umount --verbose -l ${ZDIR}{ZRAM_DEV}/ >>${ZLOG} 2>&1 
+			umount --verbose -l ${ZDIR}{ZRAM_DEV}/ >>${ZLOG} 2>&1
 		fi
 		if umount --verbose $HDD_LOG/ >>${ZLOG} 2>&1
 		then
@@ -83,10 +87,10 @@ case "$1" in
 			echo "$DEV_NUM" > /sys/class/zram-control/hot_remove
 		fi
 		invoke-rc.d rsyslog restart >>${ZLOG} 2>&1
+		exit 0
 		;;
 
 	*)
 		echo "Usage: log2ram {start|stop}" >&2
 		exit 1
-		
 esac


### PR DESCRIPTION
Added a workaround for kernels < 4.10 to solve an error caused by a missing feature. Some small changes and linting. Also added a note in README.md re: compilation issues with overlayfs-tools when kernel and gcc headers are out of sync (damn you rockchip 4.4 kernel.)

Note: "set -e" won't trigger during a logical shortcut (foo && bar; foo || bar) unless the last operation in the chain returns a `false` value. Nor will it trigger during a test block (eg: [ test foo ]).